### PR TITLE
Update __init__.py

### DIFF
--- a/mathtranslate/__init__.py
+++ b/mathtranslate/__init__.py
@@ -1,9 +1,38 @@
 __version__ = "3.1.0"
 __author__ = "MathTranslate developers"
 import os
+import shutil
+import platform
 import appdata
+
 app_paths = appdata.AppDataPaths('mathtranslate')
 app_dir = app_paths.app_data_path
+
+"""
+It appears that the `appdata` library might not follow the standard application data path conventions of macOS.
+"""
+# Check if the system is macOS
+if platform.system() == 'Darwin':
+    # Specify the new directory location for macOS
+    mac_cache_path = os.path.expanduser("~/.cache/mathtranslate")
+    
+    # If the original directory exists
+    if os.path.exists(app_dir):
+        # Remove the target directory if it already exists
+        if os.path.exists(mac_cache_path):
+            shutil.rmtree(mac_cache_path)
+        
+        # Move the content of the original directory to the new location
+        shutil.move(app_dir, mac_cache_path)
+        
+        # Update app_dir to point to the new location
+        app_dir = mac_cache_path
+    else:
+        app_dir = mac_cache_path
+else:
+    app_dir = app_paths.app_data_path
+
+# Ensure the directory is created
 os.makedirs(app_dir, exist_ok=True)
 
 from . import cache


### PR DESCRIPTION
It appears that the `appdata` library might not follow the standard application data path conventions of macOS. By default on the MacOS, the directory created is in the ~ root directory (~/mathtranslate). For a bit of OCD, it is better to create it under ~/.cache/mathtranslate. :) 