### PR TITLE
Updater timeout & Remove incompatible latex packages

### DIFF
--- a/mathtranslate/process_latex.py
+++ b/mathtranslate/process_latex.py
@@ -490,3 +490,12 @@ def remove_bibnote(latex):
         else:
             return match.group(0)
     return pattern.sub(replace_function, latex)
+
+def remove_incompatible_packages(text):
+    incompatible_list=['axessibility']
+    #axessibility is incompatible with xeCJK and can be removed savely
+    #maybe more will be added
+    for package in incompatible_list:
+        pattern = re.compile(r'\\usepackage(\[[A-Za-z]*?\])?\{'+package+r'\}') 
+        text = re.sub(pattern,'',text)
+    return text

--- a/mathtranslate/translate.py
+++ b/mathtranslate/translate.py
@@ -226,6 +226,7 @@ class LatexTranslator:
         if self.complete:
             print('It is a full latex document')
             latex_original, tex_begin, tex_end = process_latex.split_latex_document(latex_original, r'\begin{document}', r'\end{document}')
+            tex_begin = process_latex.remove_incompatible_packages(tex_begin)
             tex_begin = process_latex.remove_blank_lines(tex_begin)
             tex_begin = process_latex.insert_macro(tex_begin, '\\usepackage{xeCJK}\n\\usepackage{amsmath}')
         else:

--- a/mathtranslate/update.py
+++ b/mathtranslate/update.py
@@ -5,7 +5,7 @@ import urllib.request
 def get_latest_version():
     url = 'https://pypi.org/pypi/mathtranslate/json'
 
-    with urllib.request.urlopen(url) as response:
+    with urllib.request.urlopen(url,timeout=15) as response:
         data = json.loads(response.read().decode('utf-8'))
         latest_version = data['info']['version']
 

--- a/mathtranslate/utils.py
+++ b/mathtranslate/utils.py
@@ -74,14 +74,17 @@ split = lambda s: re.split(r'\s+', s)
 
 
 def check_update(require_updated=True):
-    latest = get_latest_version()
-    updated = __version__ == latest
-    if updated:
-        print("The current mathtranslate is latest")
-    else:
-        print("The current mathtranslate is not latest, please update by `pip install --upgrade mathtranslate`")
-        if (not config.test_environment) and require_updated:
-            sys.exit()
+    try:
+        latest = get_latest_version()
+        updated = __version__ == latest
+        if updated:
+            print("The current mathtranslate is latest")
+        else:
+            print("The current mathtranslate is not latest, please update by `pip install --upgrade mathtranslate`")
+            if (not config.test_environment) and require_updated:
+                sys.exit()
+    except Exception as e:
+        print("Checking update failed, please check your network")
 
 
 def add_arguments(parser):


### PR DESCRIPTION
* Add a 15s timeout to ensure users in China who can't connect pypi.org won't waiting forever to check for updates
* Automatically remove package **axessibility** from tex files. It will cause PDF generation failure in [website](http://mathtranslate.xyz/) when processing some particular documents. ([arXiv:2203.06604](https://arxiv.org/abs/2203.06604) for example.


